### PR TITLE
SAK-39953: enable custom copyright (default options) and copyright require choice for nightly experimental

### DIFF
--- a/experimental.properties
+++ b/experimental.properties
@@ -295,3 +295,7 @@ assignment.peerevaluationdate=1123200
 # SAK-34102
 user.type.provided.count=1
 user.type.provided.1=guest
+
+# SAK-39953 - custom copyright options
+copyright.useCustom=true
+copyright.requireChoice=true


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39953

Enables the custom copyright options (just the default ones) and the require copyright choice properties for testing purposes on nightly experimental.