### PR TITLE
SAK-39992: Announcements > new config to make email notification 'To' address match 'From' address if 'From' is replyable

### DIFF
--- a/experimental.properties
+++ b/experimental.properties
@@ -299,3 +299,7 @@ user.type.provided.1=guest
 # SAK-39953 - custom copyright options
 copyright.useCustom=true
 copyright.requireChoice=true
+
+# SAK-39992 - announcements make 'to' email address match 'from' email address if 'from' address is replyable
+announcement.notification.email.to.matches.from=true
+notify.email.from.replyable=true


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39992

Currently if your server has the property set to make Announcement emails 'From' address replyable (`notify.email.from.replyable=true`), when an announcement notification email is sent, the default 'To' address is in the format of: 

```
"[siteTitle] <noreply@[ServerConfigurationService.getServerName()]>"
```

and the 'From' address is in the format of:

```
"[lastName, firstName] <[instructor/maintainerEmail]>"
```

There may be an institutional requirement or preference to control the email address used in the 'To' address, similar to how you can control the 'From' address with the existing `mail.sendfromsakai` sakai.property.

The only configuration option for this is the `notify.email.to.replyable` sakai.property, which when set to true *and* the site contains the Email Archive, it will use the Email Archive's 'site email address' as the 'To' address in the announcement notification emails. However, the Email Archive's email address still uses `getServerName()` as the domain of the email address:

```
"[siteTitle] <[userDefinedPrefix]@[ServerConfigurationService.getServerName()]>"
```

That property doesn't solve the institutional requirement.

To address this, we introduced the sakai.property `announcement.notification.email.to.matches.from`, which defaults to false to preserve OOTB functionality. When the property is set to true, it will use the same email address used in the 'From' address for the 'To' address as well (the instructor/maintainer's email address).