### PR TITLE
SAK-39992: Announcements > new config to make email notification 'To' address match 'From' address if 'From' is replyable

### DIFF
--- a/experimental.properties
+++ b/experimental.properties
@@ -23,6 +23,7 @@ setup.request=postmaster@nightly2.sakaiproject.org
 
 #Just log the emails
 testMode@org.sakaiproject.email.api.EmailService=true
+smtpDebug@org.sakaiproject.email.api.EmailService=true
 
 #LSNBLDR-177
 lessonbuilder.cc-export=true


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39992

For printing emails to the log.