### PR TITLE
Add property samigo.allowMinScore=true

### DIFF
--- a/experimental.properties
+++ b/experimental.properties
@@ -222,6 +222,9 @@ preference.pages=prefs_noti_title, prefs_timezone_title, prefs_lang_title, prefs
 #SAM-818
 samigo.partialCreditEnabled=true
 
+#SAM-948 / SAK-34849 Minimum point value option for questions
+samigo.allowMinScore=true
+
 #SAK-32599
 content.url.rightsdialog=true
 


### PR DESCRIPTION
For testing SAK-40450 Minimum point value fails for incorrectly answered MCMS All or Nothing questions if student selects more than one correct answer option.